### PR TITLE
[Backend] 月検索機能の実装

### DIFF
--- a/backend/app/controllers/customers_controller.rb
+++ b/backend/app/controllers/customers_controller.rb
@@ -19,6 +19,11 @@ class CustomersController < ApplicationController
     render json: @customer
   end
 
+  def month_search
+    @customers = Customer.search_all_month(params[:month])
+    render json: @customers
+  end
+
   private
 
   def customer_params

--- a/backend/app/models/customer.rb
+++ b/backend/app/models/customer.rb
@@ -20,4 +20,9 @@ class Customer < ApplicationRecord
   def option_false?
     option == false
   end
+
+  def self.search_all_month(search_month)
+    search_date = "#{search_month}-01"
+    where(date: search_date.to_date.all_month)
+  end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
-  resources :customers, only: %i[index create show]
+  resources :customers, only: %i[index create show] do
+    get 'month_search', on: :collection
+  end
 end

--- a/backend/spec/models/customer_spec.rb
+++ b/backend/spec/models/customer_spec.rb
@@ -1,227 +1,243 @@
 require 'rails_helper'
 
 RSpec.describe Customer, type: :model do
-  shared_examples '有効であること' do
-    it { expect(customer).to be_valid }
-  end
+  describe 'validation' do
+    shared_examples '有効であること' do
+      it { expect(customer).to be_valid }
+    end
 
-  context '全てに値がある場合' do
-    let(:customer) { build(:customer) }
-    it_behaves_like '有効であること'
-  end
-
-  describe 'column: age' do
-    context '値がある場合' do
-      let(:customer) { build(:customer, age: '30代後半') }
+    context '全てに値がある場合' do
+      let(:customer) { build(:customer) }
       it_behaves_like '有効であること'
     end
 
-    context '値がない場合' do
-      it '無効であること' do
-        customer = build(:customer, age: '')
-        customer.valid?
-        expect(customer.errors[:age]).to include "can't be blank"
+    describe 'column: age' do
+      context '値がある場合' do
+        let(:customer) { build(:customer, age: '30代後半') }
+        it_behaves_like '有効であること'
+      end
+
+      context '値がない場合' do
+        it '無効であること' do
+          customer = build(:customer, age: '')
+          customer.valid?
+          expect(customer.errors[:age]).to include "can't be blank"
+        end
       end
     end
-  end
 
-  describe 'column: date' do
-    context '値がある場合' do
-      let(:customer) { build(:customer, date: '2000-10-14') }
-      it_behaves_like '有効であること'
-    end
+    describe 'column: date' do
+      context '値がある場合' do
+        let(:customer) { build(:customer, date: '2000-10-14') }
+        it_behaves_like '有効であること'
+      end
 
-    context '値がない場合' do
-      it '無効であること' do
-        customer = build(:customer, date: '')
-        customer.valid?
-        expect(customer.errors[:date]).to include "can't be blank"
+      context '値がない場合' do
+        it '無効であること' do
+          customer = build(:customer, date: '')
+          customer.valid?
+          expect(customer.errors[:date]).to include "can't be blank"
+        end
       end
     end
-  end
 
-  describe 'column: time' do
-    context '値がある場合' do
-      let(:customer) { build(:customer, time: '12:00') }
-      it_behaves_like '有効であること'
-    end
+    describe 'column: time' do
+      context '値がある場合' do
+        let(:customer) { build(:customer, time: '12:00') }
+        it_behaves_like '有効であること'
+      end
 
-    context '値がない場合' do
-      it '無効であること' do
-        customer = build(:customer, time: '')
-        customer.valid?
-        expect(customer.errors[:time]).to include "can't be blank"
+      context '値がない場合' do
+        it '無効であること' do
+          customer = build(:customer, time: '')
+          customer.valid?
+          expect(customer.errors[:time]).to include "can't be blank"
+        end
       end
     end
-  end
 
-  describe 'column: course' do
-    context '値がある場合' do
-      let(:customer) { build(:customer, course: '90min') }
-      it_behaves_like '有効であること'
-    end
+    describe 'column: course' do
+      context '値がある場合' do
+        let(:customer) { build(:customer, course: '90min') }
+        it_behaves_like '有効であること'
+      end
 
-    context '値がない場合' do
-      it '無効であること' do
-        customer = build(:customer, course: '')
-        customer.valid?
-        expect(customer.errors[:course]).to include "can't be blank"
+      context '値がない場合' do
+        it '無効であること' do
+          customer = build(:customer, course: '')
+          customer.valid?
+          expect(customer.errors[:course]).to include "can't be blank"
+        end
       end
     end
-  end
 
-  describe 'column: option' do
-    context 'trueの場合' do
-      let(:customer) { build(:customer, option: true) }
-      it_behaves_like '有効であること'
-    end
-
-    context 'falseの場合' do
-      let(:customer) { build(:customer, option: false) }
-      it_behaves_like '有効であること'
-    end
-
-    context 'nilの場合' do
-      it '無効であること' do
-        customer = build(:customer, option: nil)
-        customer.valid?
-        expect(customer.errors[:option]).to include 'is not included in the list'
-      end
-    end
-  end
-
-  describe 'column: cosplay' do
-    context '[option]が[true]の場合' do
+    describe 'column: option' do
       context 'trueの場合' do
-        let(:customer) { build(:customer, option: true, cosplay: true) }
+        let(:customer) { build(:customer, option: true) }
         it_behaves_like '有効であること'
       end
 
       context 'falseの場合' do
-        let(:customer) { build(:customer, option: true, cosplay: false) }
+        let(:customer) { build(:customer, option: false) }
         it_behaves_like '有効であること'
       end
 
       context 'nilの場合' do
         it '無効であること' do
-          customer = build(:customer, option: true, cosplay: nil)
+          customer = build(:customer, option: nil)
           customer.valid?
-          expect(customer.errors[:cosplay]).to include 'is not included in the list'
+          expect(customer.errors[:option]).to include 'is not included in the list'
         end
       end
     end
 
-    context '[option]が[false]の場合' do
-      context 'trueの場合' do
-        it '無効であること' do
-          customer = build(:customer, option: false, cosplay: true)
-          customer.valid?
-          expect(customer.errors[:cosplay]).to include 'is invalid'
+    describe 'column: cosplay' do
+      context '[option]が[true]の場合' do
+        context 'trueの場合' do
+          let(:customer) { build(:customer, option: true, cosplay: true) }
+          it_behaves_like '有効であること'
+        end
+
+        context 'falseの場合' do
+          let(:customer) { build(:customer, option: true, cosplay: false) }
+          it_behaves_like '有効であること'
+        end
+
+        context 'nilの場合' do
+          it '無効であること' do
+            customer = build(:customer, option: true, cosplay: nil)
+            customer.valid?
+            expect(customer.errors[:cosplay]).to include 'is not included in the list'
+          end
         end
       end
 
-      context 'falseの場合' do
-        let(:customer) { build(:customer, option: false, cosplay: false) }
-        it_behaves_like '有効であること'
+      context '[option]が[false]の場合' do
+        context 'trueの場合' do
+          it '無効であること' do
+            customer = build(:customer, option: false, cosplay: true)
+            customer.valid?
+            expect(customer.errors[:cosplay]).to include 'is invalid'
+          end
+        end
+
+        context 'falseの場合' do
+          let(:customer) { build(:customer, option: false, cosplay: false) }
+          it_behaves_like '有効であること'
+        end
+
+        context 'nilの場合' do
+          it '無効であること' do
+            customer = build(:customer, option: false, cosplay: nil)
+            customer.valid?
+            expect(customer.errors[:cosplay]).to include 'is not included in the list'
+          end
+        end
+      end
+    end
+
+    describe 'column: extended_time' do
+      context '[option]が[true]の場合' do
+        context '値が"--"である場合' do
+          let(:customer) { build(:customer, option: true, extended_time: '--') }
+          it_behaves_like '有効であること'
+        end
+
+        context '値が"--"以外である場合' do
+          let(:customer) { build(:customer, option: true, extended_time: '30min') }
+          it_behaves_like '有効であること'
+        end
+
+        context '値がない場合' do
+          it '無効であること' do
+            customer = build(:customer, option: true, extended_time: '')
+            customer.valid?
+            expect(customer.errors[:extended_time]).to include "can't be blank"
+          end
+        end
       end
 
-      context 'nilの場合' do
-        it '無効であること' do
-          customer = build(:customer, option: false, cosplay: nil)
-          customer.valid?
-          expect(customer.errors[:cosplay]).to include 'is not included in the list'
+      context '[option]が[false]の場合' do
+        context '値が"--"である場合' do
+          let(:customer) { build(:customer, option: false, extended_time: '--') }
+          it_behaves_like '有効であること'
+        end
+
+        context '値が"--"以外である場合' do
+          it '無効であること' do
+            customer = build(:customer, option: false, extended_time: '30min')
+            customer.valid?
+            expect(customer.errors[:extended_time]).to include 'is invalid'
+          end
+        end
+
+        context '値がない場合' do
+          it '無効であること' do
+            customer = build(:customer, option: false, extended_time: '')
+            customer.valid?
+            expect(customer.errors[:extended_time]).to include "can't be blank"
+          end
+        end
+      end
+    end
+
+    describe 'column: deep_lymph' do
+      context '[option]が[true]の場合' do
+        context '値が"--"である場合' do
+          let(:customer) { build(:customer, option: true, deep_lymph: '--') }
+          it_behaves_like '有効であること'
+        end
+
+        context '値が"--"以外である場合' do
+          let(:customer) { build(:customer, option: true, deep_lymph: '30min') }
+          it_behaves_like '有効であること'
+        end
+
+        context '値がない場合' do
+          it '無効であること' do
+            customer = build(:customer, option: true, deep_lymph: '')
+            customer.valid?
+            expect(customer.errors[:deep_lymph]).to include "can't be blank"
+          end
+        end
+      end
+
+      context '[option]が[false]の場合' do
+        context '値が"--"である場合' do
+          let(:customer) { build(:customer, option: false, deep_lymph: '--') }
+          it_behaves_like '有効であること'
+        end
+
+        context '値が"--"以外である場合' do
+          it '無効であること' do
+            customer = build(:customer, option: false, deep_lymph: '30min')
+            customer.valid?
+            expect(customer.errors[:deep_lymph]).to include 'is invalid'
+          end
+        end
+
+        context '値がない場合' do
+          it '無効であること' do
+            customer = build(:customer, option: false, deep_lymph: '')
+            customer.valid?
+            expect(customer.errors[:deep_lymph]).to include "can't be blank"
+          end
         end
       end
     end
   end
 
-  describe 'column: extended_time' do
-    context '[option]が[true]の場合' do
-      context '値が"--"である場合' do
-        let(:customer) { build(:customer, option: true, extended_time: '--') }
-        it_behaves_like '有効であること'
-      end
+  describe 'method' do
+    describe '#search_all_month' do
+      let!(:customers) { create_list(:customer, 10, date: Faker::Date.between(from: '2020-01-01', to: '2020-01-31')) }
+      let!(:customer) { create(:customer, date: Faker::Date.between(from: '2020-02-01', to: '2020-02-28')) }
+      subject { Customer.search_all_month('2020-1').map { |c| c['id'] } }
 
-      context '値が"--"以外である場合' do
-        let(:customer) { build(:customer, option: true, extended_time: '30min') }
-        it_behaves_like '有効であること'
-      end
+      it { is_expected.to eq(customers.map { |c| c['id'] }) }
 
-      context '値がない場合' do
-        it '無効であること' do
-          customer = build(:customer, option: true, extended_time: '')
-          customer.valid?
-          expect(customer.errors[:extended_time]).to include "can't be blank"
-        end
-      end
-    end
+      it { is_expected.not_to include customer.id }
 
-    context '[option]が[false]の場合' do
-      context '値が"--"である場合' do
-        let(:customer) { build(:customer, option: false, extended_time: '--') }
-        it_behaves_like '有効であること'
-      end
-
-      context '値が"--"以外である場合' do
-        it '無効であること' do
-          customer = build(:customer, option: false, extended_time: '30min')
-          customer.valid?
-          expect(customer.errors[:extended_time]).to include 'is invalid'
-        end
-      end
-
-      context '値がない場合' do
-        it '無効であること' do
-          customer = build(:customer, option: false, extended_time: '')
-          customer.valid?
-          expect(customer.errors[:extended_time]).to include "can't be blank"
-        end
-      end
-    end
-  end
-
-  describe 'column: deep_lymph' do
-    context '[option]が[true]の場合' do
-      context '値が"--"である場合' do
-        let(:customer) { build(:customer, option: true, deep_lymph: '--') }
-        it_behaves_like '有効であること'
-      end
-
-      context '値が"--"以外である場合' do
-        let(:customer) { build(:customer, option: true, deep_lymph: '30min') }
-        it_behaves_like '有効であること'
-      end
-
-      context '値がない場合' do
-        it '無効であること' do
-          customer = build(:customer, option: true, deep_lymph: '')
-          customer.valid?
-          expect(customer.errors[:deep_lymph]).to include "can't be blank"
-        end
-      end
-    end
-
-    context '[option]が[false]の場合' do
-      context '値が"--"である場合' do
-        let(:customer) { build(:customer, option: false, deep_lymph: '--') }
-        it_behaves_like '有効であること'
-      end
-
-      context '値が"--"以外である場合' do
-        it '無効であること' do
-          customer = build(:customer, option: false, deep_lymph: '30min')
-          customer.valid?
-          expect(customer.errors[:deep_lymph]).to include 'is invalid'
-        end
-      end
-
-      context '値がない場合' do
-        it '無効であること' do
-          customer = build(:customer, option: false, deep_lymph: '')
-          customer.valid?
-          expect(customer.errors[:deep_lymph]).to include "can't be blank"
-        end
-      end
+      it { expect(subject.length).to eq 10 }
     end
   end
 end

--- a/backend/spec/requests/customers_request_spec.rb
+++ b/backend/spec/requests/customers_request_spec.rb
@@ -48,4 +48,19 @@ RSpec.describe 'Customers', type: :request do
 
     it { expect(json['age']).to eq customer.age }
   end
+
+  describe 'GET #month_search' do
+    let!(:customers) { create_list(:customer, 10, date: Faker::Date.between(from: '2020-01-01', to: '2020-01-31')) }
+    let!(:customer) { create(:customer, date: Faker::Date.between(from: '2020-02-01', to: '2020-02-28')) }
+    before { get '/customers/month_search', params: { month: '2020-1' } }
+    subject { json.map { |j| j['id'] } }
+
+    it { expect(response).to have_http_status(:ok) }
+
+    it { expect(json.length).to eq 10 }
+
+    it { is_expected.to eq(customers.map { |c| c['id'] }) }
+
+    it { is_expected.not_to include customer.id }
+  end
 end


### PR DESCRIPTION
## What
- 一ヶ月分のデータ抽出メソッド(search_all_month)の追加
- 一ヶ月分のデータ取得アクション(month_search)の追加

## Why
余分なデータ取得をなくし、フロントエンド側のデータの扱いを容易にするため。