### PR TITLE
[Backend] customers_controller indexアクションの変更

### DIFF
--- a/backend/app/controllers/customers_controller.rb
+++ b/backend/app/controllers/customers_controller.rb
@@ -1,6 +1,6 @@
 class CustomersController < ApplicationController
   def index
-    @customers = Customer.all
+    @customers = Customer.by_month(params[:year])
     render json: @customers
   end
 

--- a/backend/app/models/customer.rb
+++ b/backend/app/models/customer.rb
@@ -21,6 +21,19 @@ class Customer < ApplicationRecord
     option == false
   end
 
+  def self.by_month(year)
+    customers = where(date: Date.new(year.to_i).all_year)
+    customers_by_month = {}
+
+    12.times do |n|
+      n += 1
+      month = Date.new(year.to_i, n).strftime('%B')
+      customers_by_month.store(month, customers.select { |c| c[:date].to_date.strftime('%B') == month })
+    end
+
+    customers_by_month
+  end
+
   def self.search_all_month(search_month)
     search_date = "#{search_month}-01"
     where(date: search_date.to_date.all_month)

--- a/backend/spec/models/customer_spec.rb
+++ b/backend/spec/models/customer_spec.rb
@@ -228,6 +228,44 @@ RSpec.describe Customer, type: :model do
   end
 
   describe 'method' do
+    describe '#by_month' do
+      let!(:customers_a) { create_list(:customer, 5, date: Faker::Date.between(from: '2020-01-01', to: '2020-01-31')) }
+      let!(:customers_b) { create_list(:customer, 6, date: Faker::Date.between(from: '2020-02-01', to: '2020-02-28')) }
+      let!(:customer) { create(:customer, date: Faker::Date.between(from: '2019-01-01', to: '2019-01-31')) }
+
+      context 'データがある場合' do
+        context "Customer.by_month('2020')['January']" do
+          subject { Customer.by_month('2020')['January'].map { |j| j['id'] } }
+
+          it { expect(Customer.by_month('2020')['January'].length).to eq 5 }
+
+          it { is_expected.to eq(customers_a.map { |c| c['id'] }) }
+
+          it { is_expected.not_to include(customers_b.map { |c| c['id'] }) }
+
+          it { is_expected.not_to include customer.id }
+        end
+
+        context "Customer.by_month('2020')['February']" do
+          subject { Customer.by_month('2020')['February'].map { |j| j['id'] } }
+
+          it { expect(Customer.by_month('2020')['February'].length).to eq 6 }
+
+          it { is_expected.to eq(customers_b.map { |c| c['id'] }) }
+
+          it { is_expected.not_to include(customers_b.map { |c| c['id'] }) }
+        end
+      end
+
+      context 'データがない場合' do
+        context "Customer.by_month('2020')['March']" do
+          it { expect(Customer.by_month('2020')['March'].length).to eq 0 }
+
+          it { expect(Customer.by_month('2020')['March']).to eq [] }
+        end
+      end
+    end
+
     describe '#search_all_month' do
       let!(:customers) { create_list(:customer, 10, date: Faker::Date.between(from: '2020-01-01', to: '2020-01-31')) }
       let!(:customer) { create(:customer, date: Faker::Date.between(from: '2020-02-01', to: '2020-02-28')) }

--- a/backend/spec/requests/customers_request_spec.rb
+++ b/backend/spec/requests/customers_request_spec.rb
@@ -4,14 +4,44 @@ RSpec.describe 'Customers', type: :request do
   let(:json) { JSON.parse(response.body) }
 
   describe 'GET #index' do
-    before do
-      create_list(:customer, 10)
-      get '/customers'
-    end
+    let!(:customers_a) { create_list(:customer, 5, date: Faker::Date.between(from: '2020-01-01', to: '2020-01-31')) }
+    let!(:customers_b) { create_list(:customer, 6, date: Faker::Date.between(from: '2020-02-01', to: '2020-02-28')) }
+    let!(:customer) { create(:customer, date: Faker::Date.between(from: '2019-01-01', to: '2019-01-31')) }
+    before { get '/customers', params: { year: '2020' } }
 
     it { expect(response).to have_http_status(:ok) }
 
-    it { expect(json.length).to eq 10 }
+    context 'データがある場合' do
+      context 'json["January"]' do
+        subject { json['January'].map { |j| j['id'] } }
+
+        it { expect(json['January'].length).to eq 5 }
+
+        it { is_expected.to eq(customers_a.map { |c| c['id'] }) }
+
+        it { is_expected.not_to include(customers_b.map { |c| c['id'] }) }
+
+        it { is_expected.not_to include customer.id }
+      end
+
+      context 'json["February"]' do
+        subject { json['February'].map { |j| j['id'] } }
+
+        it { expect(json['February'].length).to eq 6 }
+
+        it { is_expected.to eq(customers_b.map { |c| c['id'] }) }
+
+        it { is_expected.not_to include(customers_b.map { |c| c['id'] }) }
+      end
+    end
+
+    context 'データがない場合' do
+      context 'json["March"]' do
+        it { expect(json['March'].length).to eq 0 }
+
+        it { expect(json['March']).to eq [] }
+      end
+    end
   end
 
   describe 'POST #create' do


### PR DESCRIPTION
## What
- **indexアクション**の変更
- **Customerモデル**に`by_month`アクションを追加

## Why
フロントに送信するデータを月別年間に限定するため。