### PR TITLE
[Backend] Customerモデルのバリデーション変更

### DIFF
--- a/backend/app/models/customer.rb
+++ b/backend/app/models/customer.rb
@@ -13,8 +13,8 @@ class Customer < ApplicationRecord
 
   with_options if: :option_false? do
     validates :cosplay, format: { with: /\Afalse\z/ }
-    validates :extended_time, format: { with: /\A--\z/ }
-    validates :deep_lymph, format: { with: /\A--\z/ }
+    validates :extended_time, format: { with: /\A無し\z/ }
+    validates :deep_lymph, format: { with: /\A無し\z/ }
   end
 
   def option_false?

--- a/backend/spec/factories/customers.rb
+++ b/backend/spec/factories/customers.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     course { '60min' }
     option { true }
     cosplay { false }
-    extended_time { '--' }
-    deep_lymph { '--' }
+    extended_time { '無し' }
+    deep_lymph { '無し' }
   end
 end

--- a/backend/spec/models/customer_spec.rb
+++ b/backend/spec/models/customer_spec.rb
@@ -138,12 +138,12 @@ RSpec.describe Customer, type: :model do
 
     describe 'column: extended_time' do
       context '[option]が[true]の場合' do
-        context '値が"--"である場合' do
-          let(:customer) { build(:customer, option: true, extended_time: '--') }
+        context '値が"無し"である場合' do
+          let(:customer) { build(:customer, option: true, extended_time: '無し') }
           it_behaves_like '有効であること'
         end
 
-        context '値が"--"以外である場合' do
+        context '値が"無し"以外である場合' do
           let(:customer) { build(:customer, option: true, extended_time: '30min') }
           it_behaves_like '有効であること'
         end
@@ -158,12 +158,12 @@ RSpec.describe Customer, type: :model do
       end
 
       context '[option]が[false]の場合' do
-        context '値が"--"である場合' do
-          let(:customer) { build(:customer, option: false, extended_time: '--') }
+        context '値が"無し"である場合' do
+          let(:customer) { build(:customer, option: false, extended_time: '無し') }
           it_behaves_like '有効であること'
         end
 
-        context '値が"--"以外である場合' do
+        context '値が"無し"以外である場合' do
           it '無効であること' do
             customer = build(:customer, option: false, extended_time: '30min')
             customer.valid?
@@ -183,12 +183,12 @@ RSpec.describe Customer, type: :model do
 
     describe 'column: deep_lymph' do
       context '[option]が[true]の場合' do
-        context '値が"--"である場合' do
-          let(:customer) { build(:customer, option: true, deep_lymph: '--') }
+        context '値が"無し"である場合' do
+          let(:customer) { build(:customer, option: true, deep_lymph: '無し') }
           it_behaves_like '有効であること'
         end
 
-        context '値が"--"以外である場合' do
+        context '値が"無し"以外である場合' do
           let(:customer) { build(:customer, option: true, deep_lymph: '30min') }
           it_behaves_like '有効であること'
         end
@@ -203,12 +203,12 @@ RSpec.describe Customer, type: :model do
       end
 
       context '[option]が[false]の場合' do
-        context '値が"--"である場合' do
-          let(:customer) { build(:customer, option: false, deep_lymph: '--') }
+        context '値が"無し"である場合' do
+          let(:customer) { build(:customer, option: false, deep_lymph: '無し') }
           it_behaves_like '有効であること'
         end
 
-        context '値が"--"以外である場合' do
+        context '値が"無し"以外である場合' do
           it '無効であること' do
             customer = build(:customer, option: false, deep_lymph: '30min')
             customer.valid?


### PR DESCRIPTION
## What
- **extended_time** =>  `option: false`時の値を`"無し"`に変更
- **deep_lymph** => `option: false`時の値を`"無し"`に変更

## Why
フロント側での変更があったため。